### PR TITLE
Add CI workflow to check for commonly misspelled words

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -3,7 +3,7 @@
 [codespell]
 # In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
 ignore-words-list = ,
-skip = ./.git,./.licenses,__pycache__,node_modules,./go.mod,./go.sum,./package-lock.json,./poetry.lock,./yarn.lock,./LICENSE.txt,./kicad_source
+skip = ./.git,./.licenses,__pycache__,node_modules,./go.mod,./go.sum,./package-lock.json,./poetry.lock,./yarn.lock,./LICENSE.txt,./kicad_source,./CAN-Power-Injector.step
 builtin = clear,informal,en-GB_to_en-US
 check-filenames =
 check-hidden =

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,9 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/spell-check/.codespellrc
+# See: https://github.com/codespell-project/codespell#using-a-config-file
+[codespell]
+# In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
+ignore-words-list = ,
+skip = ./.git,./.licenses,__pycache__,node_modules,./go.mod,./go.sum,./package-lock.json,./poetry.lock,./yarn.lock,./LICENSE.txt,./kicad_source
+builtin = clear,informal,en-GB_to_en-US
+check-filenames =
+check-hidden =

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,0 +1,26 @@
+# Source: https://github.com/per1234/.github/blob/main/workflow-templates/spell-check.md
+name: Spell Check
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+  pull_request:
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch new misspelling detections resulting from dictionary updates.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  spellcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Spell check
+        uses: codespell-project/actions-codespell@master

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ The purpose of this board is to inject 5V DC power at up to 5A for powering CAN 
 #### Electrical Parameters
 | Name | Value |
 |-|-|
-| V_IN min | 10.5 V | set by resistor devider(R7/R8) |
+| V_IN min | 10.5 V | set by resistor divider(R7/R8) |
 | V_IN max | 40.0 V | limited by TVS diode (D4) |
 | V_CAN_OUT | 5.0 V to 5.5 V|
-| I_CAN_OUT,CONTINOUS | 5.0 A |
+| I_CAN_OUT,CONTINUOUS | 5.0 A |
 
 #### Inputs
 | Designator | Name | Connector |


### PR DESCRIPTION
On every push, pull request, and periodically, use codespell to check for commonly misspelled words.

In the event of a false positive, the problematic word should be added, in all lowercase, to the field of . Regardless of the case of the word in the false positive, it must be in all lowercase in the ignore list. The ignore list is comma-separated with no spaces.